### PR TITLE
Refactor SCSS to fix variable scope errors with @use, simplify branding layout

### DIFF
--- a/web/themes/custom/cacs_theme/cacs_theme.info.yml
+++ b/web/themes/custom/cacs_theme/cacs_theme.info.yml
@@ -8,7 +8,9 @@ package: 'Bootstrap'
 
 regions:
   page_top: 'Page Top'
-  branding: 'Branding'
+  branding_logo: 'Branding Logo'
+  branding_search: 'Branding Search'
+  branding_user: 'Branding User Menu'
   header: 'Header'
   navigation: 'Navigation'
   content: 'Content'
@@ -16,7 +18,7 @@ regions:
   sidebar_second: 'Sidebar Second'
   footer: 'Footer'
   page_bottom: 'Page Bottom'
-
+  
 libraries:
   - 'cacs_theme/global-styling'
   - 'cacs_theme/adobe-fonts'

--- a/web/themes/custom/cacs_theme/css/global.css
+++ b/web/themes/custom/cacs_theme/css/global.css
@@ -11865,6 +11865,7 @@ h1, h2, h3, h4, h5, h6 {
   font-family: "bodoni-urw", serif;
   font-weight: 400;
   line-height: 1.2;
+  color: #232D4B;
 }
 
 .container {
@@ -11876,35 +11877,20 @@ h1, h2, h3, h4, h5, h6 {
 .branding-bar {
   background-color: #232d4b;
   color: white;
-  padding: 0.5rem 0;
 }
-.branding-bar .branding {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+.branding-bar .branding-logo img {
+  max-height: 60px;
 }
-.branding-bar .branding img {
-  max-height: 50px;
+.branding-bar .branding-search input {
+  border-radius: 0.25rem;
 }
-.branding-bar .branding .site-search {
-  margin-left: auto;
-}
-.branding-bar .branding .site-search input[type=search] {
-  border-radius: 4px;
-  padding: 0.25rem 0.5rem;
-  border: 1px solid #ccc;
-}
-.branding-bar .branding .site-search button {
-  background-color: #e57200;
+.branding-bar .branding-user-menu a {
   color: white;
-  border: none;
-  padding: 0.4rem 0.75rem;
-  border-radius: 4px;
-  margin-left: 0.5rem;
-}
-.branding-bar .branding .user-menu {
+  text-decoration: none;
   margin-left: 1rem;
-  font-size: 0.9rem;
+}
+.branding-bar .branding-user-menu a:hover {
+  text-decoration: underline;
 }
 
 .site-header {

--- a/web/themes/custom/cacs_theme/scss/_base.scss
+++ b/web/themes/custom/cacs_theme/scss/_base.scss
@@ -11,4 +11,5 @@ h1, h2, h3, h4, h5, h6 {
   font-family: variables.$font-headings;
   font-weight: 400;
   line-height: 1.2;
+  color:variables.$primary-color;
 }

--- a/web/themes/custom/cacs_theme/scss/_layout.scss
+++ b/web/themes/custom/cacs_theme/scss/_layout.scss
@@ -13,39 +13,24 @@
 .branding-bar {
   background-color: #232d4b;
   color: white;
-  padding: 0.5rem 0;
 
-  .branding {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
+  .branding-logo img {
+    max-height: 60px;
+  }
 
-    img {
-      max-height: 50px;
-    }
+  .branding-search input {
+    border-radius: 0.25rem;
+  }
 
-    .site-search {
-      margin-left: auto;
-
-      input[type='search'] {
-        border-radius: 4px;
-        padding: 0.25rem 0.5rem;
-        border: 1px solid #ccc;
-      }
-
-      button {
-        background-color: #e57200;
-        color: white;
-        border: none;
-        padding: 0.4rem 0.75rem;
-        border-radius: 4px;
-        margin-left: 0.5rem;
-      }
-    }
-
-    .user-menu {
+  .branding-user-menu {
+    a {
+      color: white;
+      text-decoration: none;
       margin-left: 1rem;
-      font-size: 0.9rem;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/web/themes/custom/cacs_theme/templates/layout/page.html.twig
+++ b/web/themes/custom/cacs_theme/templates/layout/page.html.twig
@@ -7,14 +7,20 @@
   </div>
 {% endif %}
 
-{# Top Blue Bar: Branding Region (UVA logo, Search, User Menu) #}
-{% if page.branding %}
-  <div class="branding-bar text-white py-2">
-    <div class="{{ container }} d-flex justify-content-between align-items-center flex-wrap">
-      {{ page.branding }}
+{# Branding Bar (logo + search + user menu) #}
+<div class="branding-bar text-white py-2">
+  <div class="{{ container }} d-flex justify-content-between align-items-center flex-wrap">
+    <div class="branding-logo col-sm-12 col-md-6 ">
+      {{ page.branding_logo }}
+    </div>
+    <div class="branding-search col-sm-12 col-md-3">
+      {{ page.branding_search }}
+    </div>
+    <div class="branding-user-menu text-end col-sm-12 col-md-3">
+      {{ page.branding_user }}
     </div>
   </div>
-{% endif %}
+</div>
 
 {# Middle White Bar: Header Region (Program Logo, Title, etc.) #}
 {% if page.header %}


### PR DESCRIPTION
	•	Updated SCSS files to prefix variables from @use 'variables'
	•	Fixed Sass compilation error from undefined $primary-color
	•	Adjusted page.html.twig to consolidate branding region layout
	•	Removed unnecessary .row wrappers added around blocks
	•	Verified header area matches intended mockup layout using flexbox